### PR TITLE
Fix getting subscribe button status

### DIFF
--- a/youtube-auto-liker.user.js
+++ b/youtube-auto-liker.user.js
@@ -97,7 +97,7 @@
 
   const SELECTORS = {
     PLAYER: '#movie_player',
-    SUBSCRIBE_BUTTON: '#subscribe-button > ytd-subscribe-button-renderer > tp-yt-paper-button',
+    SUBSCRIBE_BUTTON: '#subscribe-button > ytd-subscribe-button-renderer',
     LIKE_BUTTON: '#menu #top-level-buttons-computed > ytd-toggle-button-renderer:nth-child(1), #segmented-like-button button',
     DISLIKE_BUTTON: '#menu #top-level-buttons-computed > ytd-toggle-button-renderer:nth-child(2), #segmented-dislike-button button'
   }
@@ -134,7 +134,7 @@
     if (!subscribeButton) {
       throw Error('Couldn\'t find sub button')
     }
-    const subscribed = subscribeButton.hasAttribute('subscribed')
+    const subscribed = subscribeButton.hasAttribute('subscribe-button-hidden')
     DEBUG.info(subscribed ? 'We are subscribed' : 'We are not subscribed')
     return subscribed
   }


### PR DESCRIPTION
Currently, `isSubscribed()` is unable to find the subscribe button because the `<tp-yt-paper-button>` tag and `subscribed` attribute no longer exist. This fix instead looks for the `subscribe-button-hidden` attribute on the `<ytd-subscribe-button-renderer>` tag.